### PR TITLE
Update hero tagline markup

### DIFF
--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -434,6 +434,7 @@
       style="{% render 'layout-panel-style', settings: section.settings %}"
     >
       {% content_for 'blocks' %}
+      <p class="subtitle h5 color-foreground" aria-label="Brand tagline">Experimental drip theory lab</p>
       <a href="#product-grid" class="button button--primary hero__shop-button">Shop Now</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show tagline as subtitle in hero section

## Testing
- `npm test` *(fails: Could not find package.json)*